### PR TITLE
Add custom API URL support

### DIFF
--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -83,9 +83,7 @@ export default defineManifest({
 			...matchOriginAsFallback,
 		},
 	],
-	host_permissions: isFirefox
-		? ["<all_urls>", "https://api.bringyour.com/*", "https://api-v4.bringyour.com/*", "https://*.ur.network/*"]
-		: ["https://api.bringyour.com/*", "https://api-v4.bringyour.com/*", "https://*.ur.network/*"],
+	host_permissions: ["<all_urls>"],
 	web_accessible_resources: [
 		{
 			resources: ["wasm/sdk.wasm", "wasm/wasm_exec.js"],

--- a/manifest.config.ts
+++ b/manifest.config.ts
@@ -84,8 +84,8 @@ export default defineManifest({
 		},
 	],
 	host_permissions: isFirefox
-		? ["<all_urls>", "https://api.bringyour.com/*", "https://api-v4.bringyour.com/*"]
-		: ["https://api.bringyour.com/*", "https://api-v4.bringyour.com/*"],
+		? ["<all_urls>", "https://api.bringyour.com/*", "https://api-v4.bringyour.com/*", "https://*.ur.network/*"]
+		: ["https://api.bringyour.com/*", "https://api-v4.bringyour.com/*", "https://*.ur.network/*"],
 	web_accessible_resources: [
 		{
 			resources: ["wasm/sdk.wasm", "wasm/wasm_exec.js"],

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -6,6 +6,7 @@ import { applyKillSwitchSetting } from "../utils/kill-switch-apply";
 import { isAllowedOrigin } from "../utils/origins";
 import { initBridge, notifySessionChanged, handleExtensionLocationChange } from "../bridge/background";
 import { startSsoFlow, clearSsoState, retrieveAndValidateState } from "../utils/sso";
+import { getStoredApiHost, buildApiBaseUrl } from "../utils/api-config";
 
 const HEALTH_ALARM_NAME = "node-health-check";
 const MULTI_IP_SLOTS_KEY = "multi_ip_slots";
@@ -74,7 +75,7 @@ async function performHealthCheck(): Promise<void> {
 		proxyManager.enableMultiIp(sorted);
 	} else {
 		const killSwitch = await getKillSwitch();
-		const pacScript = buildPacScript(sorted, { killSwitch });
+		const pacScript = await buildPacScript(sorted, { killSwitch });
 		const dataUrl = pacScriptToDataUrl(pacScript);
 
 		chrome.proxy.settings.set({
@@ -144,7 +145,8 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, _tab) => {
 });
 
 async function completeSsoLogin(code: string): Promise<void> {
-	const response = await fetch("https://api.bringyour.com/auth/code-login", {
+	const apiHost = await getStoredApiHost();
+	const response = await fetch(`${buildApiBaseUrl(apiHost)}/auth/code-login`, {
 		method: "POST",
 		headers: { "Content-Type": "application/json" },
 		body: JSON.stringify({ auth_code: code }),

--- a/src/popup/App.tsx
+++ b/src/popup/App.tsx
@@ -1,18 +1,32 @@
+import { useState, useEffect, useCallback } from "react";
 import { MemoryRouter } from "react-router-dom";
 import "./App.css";
 import { AppRoutes } from "./components/AppRoutes";
 import { chromeStorageAdapter } from "../utils/storage-adapter";
 import { AuthProvider, URNetworkAPIProvider } from "@urnetwork/sdk-js/react";
+import { getStoredApiHost, buildApiBaseUrl } from "../utils/api-config";
 
 export default function App() {
-	// const wasmUrl = chrome.runtime.getURL("wasm/sdk.wasm");
-	// const wasmExecUrl = chrome.runtime.getURL("wasm/wasm_exec.js");
+	const [apiBaseUrl, setApiBaseUrl] = useState<string | null>(null);
+	const [refreshKey, setRefreshKey] = useState(0);
+
+	useEffect(() => {
+		getStoredApiHost().then((host) => {
+			setApiBaseUrl(buildApiBaseUrl(host));
+		});
+	}, [refreshKey]);
+
+	const handleApiChange = useCallback(() => {
+		setRefreshKey((k) => k + 1);
+	}, []);
+
+	if (!apiBaseUrl) return null;
 
 	return (
 		<MemoryRouter>
-			<URNetworkAPIProvider>
+			<URNetworkAPIProvider key={refreshKey} config={{ baseURL: apiBaseUrl }}>
 				<AuthProvider storage={chromeStorageAdapter} onAuthChange={() => {}}>
-					<AppRoutes />
+					<AppRoutes onApiChange={handleApiChange} />
 				</AuthProvider>
 			</URNetworkAPIProvider>
 		</MemoryRouter>

--- a/src/popup/components/AppRoutes.tsx
+++ b/src/popup/components/AppRoutes.tsx
@@ -4,9 +4,13 @@ import AuthInitial from "./AuthInitial";
 import { ConnectScreen } from "./ConnectScreen";
 import { useAuth } from "@urnetwork/sdk-js/react";
 
-const AuthRoutes: React.FC = () => (
+interface AppRoutesProps {
+	onApiChange?: () => void;
+}
+
+const AuthRoutes: React.FC<{ onApiChange?: () => void }> = ({ onApiChange }) => (
 	<Routes>
-		<Route path="/" element={<AuthInitial />} />
+		<Route path="/" element={<AuthInitial onApiChange={onApiChange} />} />
 	</Routes>
 );
 
@@ -16,7 +20,7 @@ const MainRoutes: React.FC = () => (
 	</Routes>
 );
 
-export const AppRoutes: React.FC = () => {
+export const AppRoutes: React.FC<AppRoutesProps> = ({ onApiChange }) => {
 	const { isAuthenticated } = useAuth();
-	return isAuthenticated ? <MainRoutes /> : <AuthRoutes />;
+	return isAuthenticated ? <MainRoutes /> : <AuthRoutes onApiChange={onApiChange} />;
 };

--- a/src/popup/components/AuthInitial.tsx
+++ b/src/popup/components/AuthInitial.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { UrButton, UrInput, UrText } from "@urnetwork/elements/react";
 import { getMessage } from "@/utils/i18n";
 import { useAuth, useAuthCodeLogin } from "@urnetwork/sdk-js/react";
+import { getStoredApiHost, setStoredApiHost, getDefaultApiHost } from "@/utils/api-config";
 
 interface JWTReceivedMessage {
 	type: "JWT_RECEIVED";
@@ -9,11 +10,27 @@ interface JWTReceivedMessage {
 	networkName?: string;
 }
 
-const AuthInitial: React.FC = () => {
+interface AuthInitialProps {
+	onApiChange?: () => void;
+}
+
+const AuthInitial: React.FC<AuthInitialProps> = ({ onApiChange }) => {
 	const [authCode, setAuthCode] = useState("");
 	const [ssoLoading, setSsoLoading] = useState(false);
 	const { setAuth } = useAuth();
 	const { authCodeLogin, loading, error } = useAuthCodeLogin();
+
+	const [showApiConfig, setShowApiConfig] = useState(false);
+	const [apiHost, setApiHost] = useState(getDefaultApiHost());
+	const [apiHostInput, setApiHostInput] = useState("");
+	const [apiSaving, setApiSaving] = useState(false);
+
+	useEffect(() => {
+		getStoredApiHost().then((host) => {
+			setApiHost(host);
+			setApiHostInput(host);
+		});
+	}, []);
 
 	useEffect(() => {
 		const messageListener = (message: JWTReceivedMessage) => {
@@ -48,6 +65,34 @@ const AuthInitial: React.FC = () => {
 			console.error("Failed to initiate SSO:", err);
 		} finally {
 			setSsoLoading(false);
+		}
+	};
+
+	const handleSaveApiHost = async () => {
+		const trimmed = apiHostInput.trim();
+		if (!trimmed) return;
+		setApiSaving(true);
+		try {
+			await setStoredApiHost(trimmed);
+			const resolved = trimmed === getDefaultApiHost() ? getDefaultApiHost() : trimmed;
+			setApiHost(resolved);
+			setShowApiConfig(false);
+			onApiChange?.();
+		} finally {
+			setApiSaving(false);
+		}
+	};
+
+	const handleResetApiHost = async () => {
+		setApiSaving(true);
+		try {
+			await setStoredApiHost(getDefaultApiHost());
+			setApiHost(getDefaultApiHost());
+			setApiHostInput(getDefaultApiHost());
+			setShowApiConfig(false);
+			onApiChange?.();
+		} finally {
+			setApiSaving(false);
 		}
 	};
 
@@ -156,6 +201,65 @@ const AuthInitial: React.FC = () => {
 						</UrText>
 					</div>
 				)}
+
+				{/* Change Network API section */}
+				<div className="mt-6 pt-4 border-t border-white/10">
+					{!showApiConfig ? (
+						<button
+							type="button"
+							onClick={() => {
+								setApiHostInput(apiHost);
+								setShowApiConfig(true);
+							}}
+							className="text-[11px] opacity-40 hover:opacity-70 transition-opacity cursor-pointer"
+						>
+							{apiHost !== getDefaultApiHost()
+								? `Network API: ${apiHost}`
+								: "Change Network API"}
+						</button>
+					) : (
+						<div className="text-left">
+							<label className="block text-[11px] font-medium opacity-50 mb-1.5">
+								Network API Host
+							</label>
+							<div className="mb-2 rounded-xl overflow-hidden" style={{ background: "var(--color-surface-2)" }}>
+								<UrInput
+									placeholder="api.ur.network"
+									value={apiHostInput}
+									onInput={(e) => setApiHostInput(e.detail.value)}
+								/>
+							</div>
+							<div className="flex gap-2">
+								<UrButton
+									onClick={handleSaveApiHost}
+									loading={apiSaving}
+									disabled={apiSaving || !apiHostInput.trim()}
+									fullWidth
+									variant="secondary"
+								>
+									Save
+								</UrButton>
+								{apiHost !== getDefaultApiHost() && (
+									<UrButton
+										onClick={handleResetApiHost}
+										loading={apiSaving}
+										disabled={apiSaving}
+										variant="secondary"
+									>
+										Reset
+									</UrButton>
+								)}
+								<button
+									type="button"
+									onClick={() => setShowApiConfig(false)}
+									className="text-xs opacity-50 hover:opacity-80 px-2"
+								>
+									Cancel
+								</button>
+							</div>
+						</div>
+					)}
+				</div>
 			</div>
 		</div>
 	);

--- a/src/utils/api-config.ts
+++ b/src/utils/api-config.ts
@@ -1,0 +1,41 @@
+const API_URL_KEY = "custom_api_url";
+const DEFAULT_API_HOST = "api.bringyour.com";
+
+export const OFFICIAL_EXTENSION_IDS = {
+	chrome: "kpnklgbgjkihebbieiggfeokkddjbkfb",
+	firefox: "urnetwork@bringyour.com",
+} as const;
+
+export function getDefaultApiHost(): string {
+	return DEFAULT_API_HOST;
+}
+
+export function buildApiBaseUrl(host: string): string {
+	return `https://${host}`;
+}
+
+export async function getStoredApiHost(): Promise<string> {
+	try {
+		const result = await chrome.storage.local.get(API_URL_KEY);
+		const value = result[API_URL_KEY];
+		if (typeof value === "string" && value.trim().length > 0) {
+			return value.trim();
+		}
+	} catch {
+		// fall through
+	}
+	return DEFAULT_API_HOST;
+}
+
+export async function setStoredApiHost(host: string): Promise<void> {
+	const trimmed = host.trim();
+	if (!trimmed || trimmed === DEFAULT_API_HOST) {
+		await chrome.storage.local.remove(API_URL_KEY);
+	} else {
+		await chrome.storage.local.set({ [API_URL_KEY]: trimmed });
+	}
+}
+
+export async function clearStoredApiHost(): Promise<void> {
+	await chrome.storage.local.remove(API_URL_KEY);
+}

--- a/src/utils/connection-manager.ts
+++ b/src/utils/connection-manager.ts
@@ -196,7 +196,7 @@ export class ConnectionManager {
 			});
 		} else {
 			const killSwitch = await getKillSwitch();
-			const pacScript = buildPacScript(slotList, { killSwitch });
+			const pacScript = await buildPacScript(slotList, { killSwitch });
 			const dataUrl = pacScriptToDataUrl(pacScript);
 			response = await chrome.runtime.sendMessage({
 				type: "ENABLE_TAB_ISOLATION_PAC",

--- a/src/utils/kill-switch-apply.ts
+++ b/src/utils/kill-switch-apply.ts
@@ -25,7 +25,7 @@ export async function applyKillSwitchSetting(enabled: boolean): Promise<void> {
 				const slots = JSON.parse(raw) as PacSlot[];
 				const health = await getStoredHealth();
 				const sorted = getSortedSlots(slots, health);
-				const pacScript = buildPacScript(sorted, { killSwitch: enabled });
+				const pacScript = await buildPacScript(sorted, { killSwitch: enabled });
 				const dataUrl = pacScriptToDataUrl(pacScript);
 				chrome.proxy.settings.set({
 					value: { mode: "pac_script", pacScript: { url: dataUrl } },

--- a/src/utils/pac-script.ts
+++ b/src/utils/pac-script.ts
@@ -1,4 +1,5 @@
 import { pacBypassConditions, deviceRpcApiHost } from "./bypass-rules";
+import { getStoredApiHost } from "./api-config";
 
 export interface PacSlot {
 	host: string;
@@ -9,7 +10,7 @@ export interface BuildPacOptions {
 	killSwitch?: boolean;
 }
 
-export function buildPacScript(slots: PacSlot[], options: BuildPacOptions = {}): string {
+export async function buildPacScript(slots: PacSlot[], options: BuildPacOptions = {}): Promise<string> {
 	const { killSwitch = true } = options;
 
 	if (slots.length === 0) {
@@ -26,12 +27,16 @@ export function buildPacScript(slots: PacSlot[], options: BuildPacOptions = {}):
 	const fallback = killSwitch ? "" : "; DIRECT";
 
 	// each slot's own device-rpc api host stays direct (see deviceRpcApiHost)
-	const apiHosts = slots
+	const deviceHosts = slots
 		.map((s) => deviceRpcApiHost(s.host))
 		.filter((h): h is string => h !== null);
 
+	// a configured custom API host must also stay direct, or the extension
+	// can't reach it while the VPN is routing everything else
+	const customApiHost = await getStoredApiHost();
+
 	return `function FindProxyForURL(url, host) {
-  ${pacBypassConditions(apiHosts)}
+  ${pacBypassConditions([...deviceHosts, customApiHost])}
   return "${proxyList}${fallback}";
 }`;
 }

--- a/src/utils/proxy-manager.ts
+++ b/src/utils/proxy-manager.ts
@@ -1,6 +1,7 @@
 import type { PacSlot } from "./pac-script";
 import { shouldBypass, chromeBypassList, deviceRpcApiHost } from "./bypass-rules";
 import { getKillSwitch } from "./kill-switch";
+import { getStoredApiHost } from "./api-config";
 
 export interface ProxyConfig {
 	host: string;
@@ -54,9 +55,17 @@ class ProxyManager {
 	private firefoxListener: ((details: FirefoxProxyDetails) => FirefoxProxyInfo[]) | null = null;
 	private firefoxMultiIpSlots: PacSlot[] = [];
 	private killSwitchEnabled = true;
+	// The configured custom API host, if any (see utils/api-config). Cached
+	// in-memory and refreshed at connect time so the per-request Firefox
+	// listener closures can consult it synchronously.
+	private customApiHost: string | null = null;
 
 	async loadKillSwitch(): Promise<void> {
 		this.killSwitchEnabled = await getKillSwitch();
+	}
+
+	async refreshCustomApiHost(): Promise<void> {
+		this.customApiHost = await getStoredApiHost();
 	}
 
 	setKillSwitchState(enabled: boolean): void {
@@ -86,9 +95,11 @@ class ProxyManager {
 
 			try {
 				const { hostname } = new URL(details.url);
-				// the connected proxy's own device-rpc api host must stay direct
+				// the connected proxy's own device-rpc api host, and any configured
+				// custom API host, must stay direct
 				const apiHost = deviceRpcApiHost(config.host);
-				if (shouldBypass(hostname, apiHost ? [apiHost] : [])) return [{ type: "direct" }];
+				const extraHosts = [apiHost, this.customApiHost].filter((h): h is string => h !== null);
+				if (shouldBypass(hostname, extraHosts)) return [{ type: "direct" }];
 			} catch {
 				return [{ type: "direct" }];
 			}
@@ -164,7 +175,8 @@ class ProxyManager {
 				const apiHosts = this.firefoxMultiIpSlots
 					.map((s) => deviceRpcApiHost(s.host))
 					.filter((h): h is string => h !== null);
-				if (shouldBypass(hostname, apiHosts)) return [{ type: "direct" }];
+				const extraHosts = this.customApiHost ? [...apiHosts, this.customApiHost] : apiHosts;
+				if (shouldBypass(hostname, extraHosts)) return [{ type: "direct" }];
 			} catch {
 				return [{ type: "direct" }];
 			}
@@ -286,6 +298,8 @@ class ProxyManager {
 
 	/** Enable the VPN proxy with the given configuration. */
 	async enable(config: ProxyConfig): Promise<void> {
+		await this.refreshCustomApiHost();
+
 		if (isFirefoxProxyApiAvailable()) {
 			this.addFirefoxProxyListener(config);
 			this.state = { enabled: true, mode: "fixed", config };
@@ -305,7 +319,9 @@ class ProxyManager {
 					port: config.port,
 				},
 				bypassList: chromeBypassList(
-					[deviceRpcApiHost(config.host)].filter((h): h is string => h !== null),
+					[deviceRpcApiHost(config.host), this.customApiHost].filter(
+						(h): h is string => h !== null,
+					),
 				),
 			},
 		};
@@ -374,6 +390,7 @@ class ProxyManager {
 	/** Restore proxy state on extension startup. */
 	async restoreState(): Promise<void> {
 		await this.loadKillSwitch();
+		await this.refreshCustomApiHost();
 
 		if (isFirefoxProxyApiAvailable()) {
 			const result = await chrome.storage.local.get([

--- a/src/utils/use-provider-list-enhanced.ts
+++ b/src/utils/use-provider-list-enhanced.ts
@@ -4,9 +4,9 @@ import type {
 	ConnectLocation,
 	FindLocationsResult,
 } from "node_modules/@urnetwork/sdk-js/dist/generated";
+import { getStoredApiHost, buildApiBaseUrl } from "./api-config";
 
 const DEBOUNCE_MS = 400;
-const API_BASE = "https://api.bringyour.com";
 
 export interface RegionGroup {
 	region: ConnectLocation;
@@ -192,7 +192,8 @@ export function useProviderListEnhanced() {
 			if (searchQuery.length === 0) {
 				result = await (api as any).networkProviderLocations();
 			} else {
-				const response = await fetch(`${API_BASE}/network/find-provider-locations`, {
+				const apiBase = buildApiBaseUrl(await getStoredApiHost());
+				const response = await fetch(`${apiBase}/network/find-provider-locations`, {
 					method: "POST",
 					headers: { "Content-Type": "application/json" },
 					body: JSON.stringify({


### PR DESCRIPTION
## Summary
- Adds a "Change Network API" option on the pre-auth screen so the extension can point at a non-default API host (`api.bringyour.com`), storing it in `chrome.storage.local` via a new `src/utils/api-config.ts`.
- Wires the custom host through the SSO code-login request, the provider-locations search request, and the popup's `URNetworkAPIProvider` base URL.
- Threads the custom host into the existing bypass-rules `extraHosts` mechanism (alongside the device-rpc bypass host) so traffic to the configured API host stays direct instead of being routed through the VPN proxy, for both the Chrome bypass list and the Firefox PAC/`proxy.onRequest` paths.
- Widens `host_permissions` to `<all_urls>` for both browsers, since the API host is no longer fixed to the two hardcoded `bringyour.com` hosts.

## Notes
- Rebased/merged onto current `main`, which had since added the device-rpc bypass routing (app-bridge) and the shared `applyKillSwitchSetting` helper — the bypass-host plumbing and kill-switch call site were adapted to build on those rather than duplicating them.
- `buildPacScript` became `async` again (it needs to read the stored API host); one caller in `kill-switch-apply.ts` was updated to await it.

## Test plan
- [x] `tsc -b` passes
- [x] `vitest run` — 25/25 tests pass
- [x] `npm run build` and `npm run build:firefox` produce valid Chrome/Firefox zips with `host_permissions: ["<all_urls>"]`
- [ ] Manual smoke test: configure a custom API host on the login screen, confirm auth/provider-list calls hit it and it stays reachable while the VPN is connected