### PR TITLE
ci: build and test the extension on push

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,4 +1,9 @@
-name: Build and test - extension
+# Build and test the extension on every push and pull request.
+#
+# THIS WORKFLOW DOES NOT RELEASE ANYTHING. No signing, no store upload, no
+# npm publish, no secrets of any kind. The two zips it produces are a CI
+# artifact for inspection only.
+name: Build and test — extension
 
 on:
   push:
@@ -12,10 +17,16 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build-and-test:
     name: lint, test, build (chrome + firefox)
     runs-on: ubuntu-latest
+    # the whole job runs in about a minute; this only catches a hang.
+    timeout-minutes: 15
     steps:
       - name: Check out extension
         uses: actions/checkout@v4
@@ -23,9 +34,9 @@ jobs:
       # package.json declares no `engines` and no `packageManager`, so nothing
       # in the repo pins a toolchain. The release pipeline (build/all/run.sh)
       # gates on node 24.14.1 + npm 11.11.0, but that gate is for the whole
-      # release build, not this repo: the only hard floor here is vite 7's
-      # `^20.19.0 || >=22.12.0`, and package-lock.json is lockfileVersion 3,
-      # which any npm >= 7 installs identically. Pinning the node 24 major
+      # release build, not this repo: the binding floors here are vite 7's
+      # `^20.19.0 || >=22.12.0` and vitest 4's `^20 || ^22 || >=24`, which
+      # together mean node ^20.19 || ^22.12 || >=24. Pinning the node 24 major
       # keeps CI on the same line the pipeline ships from without pretending
       # the patch release matters.
       - name: Set up Node
@@ -41,11 +52,17 @@ jobs:
         run: npm ci --no-audit --no-fund
 
       # `eslint .` reports 12 errors on a fresh checkout of main, before any
-      # change of ours: 10 x @typescript-eslint/no-explicit-any, one unused
-      # `_tab`, and two react-hooks "Cannot access refs during render" in
-      # elements/src. They are pre-existing style debt, not a broken build, so
-      # lint is reported but not allowed to gate the thing this workflow is
-      # for. Drop continue-on-error once main lints clean.
+      # change of ours: 9 x @typescript-eslint/no-explicit-any (in
+      # src/background/index.ts, src/utils/{connection-manager,kill-switch-apply,
+      # proxy-manager,sso,use-provider-list-enhanced}.ts), one unused `_tab` at
+      # src/background/index.ts:126, and two react-hooks "Cannot access refs
+      # during render" at src/utils/use-connection-manager.ts:27-28. They are
+      # pre-existing style debt, not a broken build, so lint is reported but not
+      # allowed to gate the thing this workflow is for -- the same mechanism
+      # connect/test.yml uses for its non-blocking extender step. Note the
+      # difference from that precedent: connect's step covers a genuinely flaky
+      # test, this one covers deterministic debt, so it will be red every single
+      # run until someone fixes it. Drop continue-on-error once main lints clean.
       - name: Lint (pre-existing failures, non-blocking)
         continue-on-error: true
         run: npm run lint

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -40,7 +40,14 @@ jobs:
       - name: Install
         run: npm ci --no-audit --no-fund
 
-      - name: Lint
+      # `eslint .` reports 12 errors on a fresh checkout of main, before any
+      # change of ours: 10 x @typescript-eslint/no-explicit-any, one unused
+      # `_tab`, and two react-hooks "Cannot access refs during render" in
+      # elements/src. They are pre-existing style debt, not a broken build, so
+      # lint is reported but not allowed to gate the thing this workflow is
+      # for. Drop continue-on-error once main lints clean.
+      - name: Lint (pre-existing failures, non-blocking)
+        continue-on-error: true
         run: npm run lint
 
       # tsconfig.test.json is not referenced from tsconfig.json, so the `tsc -b`

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,103 @@
+name: Build and test - extension
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-test:
+    name: lint, test, build (chrome + firefox)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out extension
+        uses: actions/checkout@v4
+
+      # package.json declares no `engines` and no `packageManager`, so nothing
+      # in the repo pins a toolchain. The release pipeline (build/all/run.sh)
+      # gates on node 24.14.1 + npm 11.11.0, but that gate is for the whole
+      # release build, not this repo: the only hard floor here is vite 7's
+      # `^20.19.0 || >=22.12.0`, and package-lock.json is lockfileVersion 3,
+      # which any npm >= 7 installs identically. Pinning the node 24 major
+      # keeps CI on the same line the pipeline ships from without pretending
+      # the patch release matters.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+
+      # ci, not install: the lockfile is the contract, and every dependency
+      # (@urnetwork/sdk-js and @urnetwork/localizations included) resolves from
+      # the public registry, so no token is needed.
+      - name: Install
+        run: npm ci --no-audit --no-fund
+
+      - name: Lint
+        run: npm run lint
+
+      # tsconfig.test.json is not referenced from tsconfig.json, so the `tsc -b`
+      # inside `npm run build` never type-checks tests/. Checking it explicitly
+      # is what test.sh does.
+      - name: Type-check tests
+        run: npm run test:types
+
+      # the suite is offline by construction -- tests/setup.ts stubs fetch to
+      # reject -- so it needs no network, no secrets and no browser.
+      - name: Test
+        run: npm test
+
+      # same two commands the Makefile runs, minus the local-sibling
+      # localizations overlay build.sh does: scripts/build-locales.js falls back
+      # to the published @urnetwork/localizations package on a standalone
+      # checkout, which is exactly the CI case.
+      - name: Build (chrome)
+        run: npm run build
+
+      - name: Build (firefox)
+        run: npm run build:firefox
+
+      # vite-plugin-zip-pack is the last thing to run in each build, so a
+      # missing or trivially small zip means a build that reported success
+      # without producing a loadable extension.
+      - name: Verify both extension zips
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          for zip in \
+            "release/crx-@urnetwork-extension-${version}.zip" \
+            "release/crx-@urnetwork-extension-${version}-firefox.zip"
+          do
+            if [ ! -f "$zip" ]; then
+              echo "missing: $zip"
+              ls -la release || true
+              exit 1
+            fi
+            size=$(stat -c%s "$zip")
+            echo "$zip: $size bytes"
+            if [ "$size" -lt 100000 ]; then
+              echo "$zip is too small to be a real build"
+              exit 1
+            fi
+          done
+          # the firefox patch step rewrites background.* in place; if it did not
+          # run, the manifest still has chrome's service_worker
+          node -e '
+            const m = require("./dist-firefox/manifest.json");
+            if (!Array.isArray(m.background?.scripts)) {
+              throw new Error("dist-firefox manifest was not patched for firefox");
+            }
+          '
+
+      - name: Upload the extension zips
+        uses: actions/upload-artifact@v4
+        with:
+          name: urnetwork-extension-zips
+          path: release/*.zip


### PR DESCRIPTION
First CI for this repo: build and test on every push and PR to `main`, plus manual dispatch. One file, `.github/workflows/build-and-test.yml`, nothing else changes.

**It is green, and it is fast: the whole job takes about a minute.**

## What it runs

One `ubuntu-latest` job, using the repo's own entry points:

| Step | Command | Result |
|---|---|---|
| Install | `npm ci --no-audit --no-fund` | clean |
| Lint | `npm run lint` | **12 pre-existing errors — reported, non-blocking** (see below) |
| Type-check tests | `npm run test:types` | clean |
| Test | `npm test` | **28 tests / 3 files passed** in 0.4s |
| Build (chrome) | `npm run build` | built in ~2s |
| Build (firefox) | `npm run build:firefox` | built in ~2s |
| Verify | — | both zips present at ~9.9 MB, firefox manifest confirmed patched |
| Upload | `actions/upload-artifact@v4` | both zips, for inspection only |

`test:types` is checked separately because `tsconfig.test.json` is not referenced from `tsconfig.json` — the `tsc -b` inside `npm run build` never sees `tests/`. `test.sh` checks it separately for the same reason. The two build commands are exactly what the `Makefile` runs.

The job carries `timeout-minutes: 15` (a hang guard, not a budget — it finishes in ~1 min) and a `concurrency` group keyed on workflow + ref with `cancel-in-progress`, so pushing twice to a branch does not leave two runs racing.

## The one judgement call: lint does not gate

`eslint .` fails on a fresh checkout of `main` with 12 errors that predate this PR:

- 9 × `@typescript-eslint/no-explicit-any` — `src/background/index.ts:17,21,110`, `src/utils/connection-manager.ts:61`, `src/utils/kill-switch-apply.ts:9`, `src/utils/proxy-manager.ts:39,40`, `src/utils/sso.ts:51`, `src/utils/use-provider-list-enhanced.ts:193`
- 1 × unused `_tab` — `src/background/index.ts:126`
- 2 × react-hooks "Cannot access refs during render" — `src/utils/use-connection-manager.ts:27-28`, where `authFnRef.current` and `removeFnRef.current` are assigned during render

None are auto-fixable, so gating lint means real code changes. The first push of this workflow proved the cost of gating: lint failed and **the tests and both builds never ran at all**.

So lint gets the same mechanism `connect/test.yml` gives its non-blocking extender step — it still runs, still reports in the log, but a pre-existing failure is not allowed to gate the build-and-test this workflow exists for. **One honest difference from that precedent, called out in the file too:** connect's step covers a genuinely *flaky* test, this one covers *deterministic* debt, so it will be red on every single run until someone fixes it, and a permanently red step is easier to stop noticing than a sometimes-red one.

**Maintainer decision:** leave it reported-but-non-blocking as shipped, or fix the 12 on `main` first and drop `continue-on-error`. The comment in the file says to drop it once `main` lints clean. Happy to flip it.

## No secrets

Nothing here needs a credential, and nothing is skipped to avoid one:

- `@urnetwork/sdk-js` (`0.0.1-beta.5`) and `@urnetwork/localizations` (`0.0.6`) are **public** on registry.npmjs.org — every entry in `package-lock.json` resolves from that one registry, and `npm ci` ran clean with no token.
- The tests are offline by construction: `tests/setup.ts` stubs `fetch` to reject, so a leaked network call fails loudly rather than reaching `api.bringyour.com`.
- No signing, no store upload, no `npm publish`, no release. The two zips are a CI artifact only.

## Node version

`package.json` declares no `engines` and no `packageManager`, so the repo pins nothing itself. The release pipeline (`build/all/run.sh`) gates on node 24.14.1 / npm 11.11.0, but that is a whole-pipeline reproducibility gate that fires once before any repo is pulled. For this repo alone the binding floors are vite 7's `^20.19.0 || >=22.12.0` and vitest 4's `^20 || ^22 || >=24` — together, node `^20.19 || ^22.12 || >=24`. The workflow pins the node **24 major** to stay on the line the pipeline ships from, without pretending the patch matters.

Note this differs from `web/build.yml`'s `node-version: latest`, which is unpinned and drifts onto whatever shipped that week, including non-LTS odd majors. `lts/*` would also satisfy the floors if you prefer that.

## One known divergence from the release build

`build.sh` rsyncs the sibling `localizations` checkout over the installed package before building, because for a `0.0.x` dependency npm treats `^` as exact — a key added to the store is invisible until the package is republished *and* the dependency bumped. CI has no sibling checkout, so `scripts/build-locales.js` takes its own documented fallback and uses published `@urnetwork/localizations@0.0.6`. The build is complete and real; it just validates against the published key set, so **CI will not catch localization key drift** (registry `latest` is already 0.0.7 against the locked 0.0.6).

Closing that gap is possible but is not a one-liner: `localizations/index.js` imports `js-yaml` as a bare specifier, and Node resolves those only up *ancestor* directories, so a bare sibling clone cannot see this repo's `node_modules` — and `resolveLoadAllKeys` does its `await import(siblingIndex)` with no try/catch, so it would fail the prebuild rather than fall back. It needs the clone *and* `npm ci` inside it. Deliberately left out of a first CI to keep the workflow small; say the word and I will add it.

## What this deliberately does not do

No release, no signing, no store/AMO upload, no publish, no secrets, and no browser-driven end-to-end tests. Purely: does it install, type-check, test, and build for both targets.

Draft: opened for review, not to merge as-is.
